### PR TITLE
Don't hide message if it's NoneType

### DIFF
--- a/files/NautilusOutputDevice.py
+++ b/files/NautilusOutputDevice.py
@@ -71,7 +71,7 @@ class NautilusOutputDevice(OutputDevice):
         self._stream = None
         self._cleanupRequest()
 
-        if hasattr(self, '_message'):
+        if hasattr(self, '_message') and self._message:
             self._message.hide()
         self._message = None
 


### PR DESCRIPTION
So I was looking at the crashes coming in through Cura's crash reporter, where people got Cura to crash and then pressed the "send report" button. I found this one here that might be of interest to you: https://sentry.io/share/issue/eabf143e79384aad9990bda413a4f7cd/ (I don't think you need to log in with this link, but let me know if you can't see it.)

Out of interest I looked into your plug-in to see how this error could happen. Honestly, I didn't completely work it out. This `_message` is not set during the start-up, but only in a bunch of the methods of this output device. Those methods include functions called by Cura upon signal emits which could happen at any time. Perhaps those methods create a `Message` object during the execution of the `__init__` method. After all, that's probably why you wrote this bit of code here in the first place. Well, I'm figuring some of those might also then set the `_message` field to None which would cause this error.

This small fix should prevent the error. It's probably not very common at all, but hey I was rummaging through that code anyway.